### PR TITLE
fix a compilation issue due to mismatching signature for RunCommandBackground

### DIFF
--- a/testbed.go
+++ b/testbed.go
@@ -20,4 +20,6 @@ type Testbed interface {
 	Setup(start bool, env string, numNodes int) error
 	Teardown()
 	GetNodes() []TestbedNode
+	GetNode(name string) TestbedNode
+	IterateNodes(fn func(TestbedNode) error)
 }

--- a/testbednode.go
+++ b/testbednode.go
@@ -19,6 +19,6 @@ package vagrantssh
 type TestbedNode interface {
 	RunCommand(cmd string) (err error)
 	RunCommandWithOutput(cmd string) (output string, err error)
-	RunCommandBackground(cmd string) (output string, err error)
+	RunCommandBackground(cmd string) (err error)
 	GetName() string
 }


### PR DESCRIPTION
also moved GetNode() and IterateNodes() methods to the Testbed interface

@erikh PTAL
