### PR TITLE
Retry ssh connection if it fails

### DIFF
--- a/sshnode.go
+++ b/sshnode.go
@@ -24,6 +24,12 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// MaxSSHRetries is the number of times we'll retry SSH connection
+var MaxSSHRetries = 3
+
+// SSHRetryDelay is the delay between SSH connection retries
+var SSHRetryDelay = time.Second
+
 // SSHNode implements a node with ssh connectivity in a testbed
 type SSHNode struct {
 	Name      string
@@ -84,17 +90,17 @@ func (n *SSHNode) getClientAndSession() (*ssh.Client, *ssh.Session, error) {
 	var err error
 
 	// Retry few times if ssh connection fails
-	for i := 0; i < 3; i++ {
+	for i := 0; i < MaxSSHRetries; i++ {
 		client, err = n.dial()
 		if err != nil {
-			time.Sleep(time.Second)
+			time.Sleep(SSHRetryDelay)
 			continue
 		}
 
 		s, err = client.NewSession()
 		if err != nil {
 			client.Close()
-			time.Sleep(time.Second)
+			time.Sleep(SSHRetryDelay)
 			continue
 		}
 


### PR DESCRIPTION
Retry ssh connection with a 1sec delay if it fails
We seem to see quite a few SSH failures during system test runs even though max-sessions is set to 1000. This retries the connection few times
