### PR TITLE
Vagrantfile: bump Vagrant box 0.10.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,9 +3,9 @@ Vagrant.configure(2) do |config|
     v.linked_clone = true if Vagrant::VERSION >= "1.8"
   end
   config.vm.box = "contiv/centos73"
+  config.vm.box_version = "0.10.2"
   (0..2).each do |x|
     config.vm.define "host#{x}" do |host|
-    config.vm.box_version = "0.10.0"
     # use a private key from within the repo for demo environment. This is used for
     # baremetal test
     config.ssh.insert_key = false


### PR DESCRIPTION
This small PR bumps the Vagrant box to the latest version. This makes remotessh run the tests with Go 1.7.6.